### PR TITLE
feat: Implemented lender details page

### DIFF
--- a/src/app/(protected)/error.tsx
+++ b/src/app/(protected)/error.tsx
@@ -6,7 +6,7 @@ type ErrorProps = {
   reset: () => void;
 };
 
-export default function ApplicationsError({ reset }: ErrorProps) {
+export default function ProtectedError({ reset }: ErrorProps) {
   return (
     <div className="min-h-screen p-8 pb-20 sm:p-20 font-sans grid place-items-center">
       <div className="max-w-xl w-full text-center space-y-4">
@@ -14,7 +14,7 @@ export default function ApplicationsError({ reset }: ErrorProps) {
           Something went wrong
         </h1>
         <p className="text-muted-foreground">
-          We couldn&apos;t load the applications. You can try again.
+          We couldn&apos;t load the requested data. You can try again.
         </p>
         <div className="flex items-center justify-center gap-3 pt-2">
           <Button onClick={() => reset()}>Try again</Button>

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import RequireAuth from "@/components/require-auth";
 import { AppSidebar } from "@/components/app-sidebar";
+import RequireAuth from "@/components/require-auth";
 import {
   SidebarInset,
   SidebarProvider,
@@ -18,10 +18,13 @@ export default function ProtectedLayout({
       <SidebarProvider>
         <AppSidebar />
         <SidebarInset className="min-w-0">
-          <header className="flex h-14 shrink-0 items-center gap-2 px-4 sticky top-0 z-10 bg-background supports-[backdrop-filter]:bg-background/80 backdrop-blur">
+          <header
+            key="header"
+            className="flex h-14 shrink-0 items-center gap-2 px-4 sticky top-0 z-10 bg-background supports-[backdrop-filter]:bg-background/80 backdrop-blur"
+          >
             <SidebarTrigger className="-ml-1" />
           </header>
-          {children}
+          <div key="content">{children}</div>
         </SidebarInset>
       </SidebarProvider>
     </RequireAuth>

--- a/src/app/(protected)/lenders/[id]/page.tsx
+++ b/src/app/(protected)/lenders/[id]/page.tsx
@@ -1,0 +1,266 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { fetchLender } from "@/lib/fetchLender";
+import { transformMatchingLenders } from "@/lib/transformers";
+import { ArrowLeftToLine } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { id } = await params;
+  const lender = await fetchLender(id);
+
+  return {
+    title: `${lender?.lender_name || "Lender"} | Details`,
+    description: `View details for ${
+      lender?.lender_name || "lender"
+    } including contact information and lending criteria.`,
+  };
+}
+
+export default async function LenderDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  const lender = await fetchLender(id);
+
+  if (!lender) notFound();
+
+  const transformedLender = transformMatchingLenders([lender])[0];
+  const lenderName = transformedLender.lenderName || "Unknown Lender";
+  const companyName = transformedLender.companyName || "";
+
+  const lendingStates = transformedLender.lendingStates;
+  const propertyTypes = transformedLender.propertyTypes;
+  const loanRangeDisplay = transformedLender.loanRangeDisplay;
+
+  return (
+    <main className="w-full">
+      <Breadcrumb className="mb-6">
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link href="/lenders">Lenders</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>{lenderName}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-8">
+        <div className="min-w-0">
+          <div className="mb-2">
+            <Link
+              href="/lenders"
+              aria-label="Back to List"
+              className="inline-flex items-center gap-1.5 hover:underline"
+            >
+              <ArrowLeftToLine className="size-4" />
+              <span className="sm:inline">Back to List</span>
+            </Link>
+          </div>
+          <h1 className="text-3xl sm:text-4xl font-bold tracking-tight mb-2">
+            {lenderName}
+          </h1>
+          <p className="text-muted-foreground">
+            {companyName || "Lender Details"}
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {/* Contact Information */}
+          <Card>
+            <CardHeader className="border-b">
+              <CardTitle className="text-sm tracking-wide uppercase text-muted-foreground">
+                Contact Information
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="py-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <div className="text-xs text-muted-foreground">
+                    Contact Name
+                  </div>
+                  <div className="text-sm font-medium">
+                    {transformedLender.contactName || "-"}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-xs text-muted-foreground">Company</div>
+                  <div className="text-sm font-medium">
+                    {companyName || "-"}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-xs text-muted-foreground">Phone</div>
+                  <div className="text-sm font-medium">
+                    {transformedLender.contactPhone || "-"}
+                  </div>
+                  {lender.contact_phone_notes && (
+                    <div className="text-xs text-muted-foreground mt-1">
+                      {lender.contact_phone_notes}
+                    </div>
+                  )}
+                </div>
+                <div>
+                  <div className="text-xs text-muted-foreground">Email</div>
+                  <div className="text-sm font-medium break-words">
+                    {transformedLender.contactEmail || "-"}
+                  </div>
+                  {lender.contact_email_notes && (
+                    <div className="text-xs text-muted-foreground mt-1">
+                      {lender.contact_email_notes}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Lending Criteria */}
+          <Card>
+            <CardHeader className="border-b">
+              <CardTitle className="text-sm tracking-wide uppercase text-muted-foreground">
+                Lending Criteria
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="py-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <div className="text-xs text-muted-foreground">
+                    Loan Range
+                  </div>
+                  <div className="text-sm font-medium">{loanRangeDisplay}</div>
+                </div>
+                <div>
+                  <div className="text-xs text-muted-foreground">
+                    Maximum LTV
+                  </div>
+                  <div className="text-sm font-medium">
+                    {transformedLender.maxLtvDisplay || "-"}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-xs text-muted-foreground">
+                    Minimum FICO Score
+                  </div>
+                  <div className="text-sm font-medium">
+                    {transformedLender.ficoMinDisplay || "-"}
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {/* Geographic Coverage */}
+          <Card>
+            <CardHeader className="border-b">
+              <CardTitle className="text-sm tracking-wide uppercase text-muted-foreground">
+                Geographic Coverage
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="py-4">
+              <div>
+                <div className="text-xs text-muted-foreground mb-2">
+                  Lending States
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  {lendingStates.length > 0 ? (
+                    lendingStates.slice(0, 10).map((state) => (
+                      <Badge
+                        key={state}
+                        variant="secondary"
+                        className="text-xs"
+                      >
+                        {state}
+                      </Badge>
+                    ))
+                  ) : (
+                    <span className="text-sm text-muted-foreground">
+                      No states specified
+                    </span>
+                  )}
+                  {lendingStates.length > 10 && (
+                    <Badge variant="outline" className="text-xs">
+                      +{lendingStates.length - 10} more
+                    </Badge>
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Property Types */}
+          <Card>
+            <CardHeader className="border-b">
+              <CardTitle className="text-sm tracking-wide uppercase text-muted-foreground">
+                Property Types
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="py-4">
+              <div className="space-y-4">
+                <div>
+                  <div className="text-xs text-muted-foreground mb-2">
+                    Supported Types
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    {propertyTypes.length > 0 ? (
+                      propertyTypes.slice(0, 8).map((type) => (
+                        <Badge
+                          key={type}
+                          variant="secondary"
+                          className="text-xs"
+                        >
+                          {type}
+                        </Badge>
+                      ))
+                    ) : (
+                      <span className="text-sm text-muted-foreground">
+                        No types specified
+                      </span>
+                    )}
+                    {propertyTypes.length > 8 && (
+                      <Badge variant="outline" className="text-xs">
+                        +{propertyTypes.length - 8} more
+                      </Badge>
+                    )}
+                  </div>
+                </div>
+                {transformedLender.notes && (
+                  <div>
+                    <div className="text-xs text-muted-foreground mb-1">
+                      Additional Notes
+                    </div>
+                    <div className="text-sm text-muted-foreground">
+                      {transformedLender.notes}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(protected)/loading.tsx
+++ b/src/app/(protected)/loading.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "@/components/ui/loading-spinner";
 
-export default function LoadingApplications() {
+export default function LoadingProtected() {
   return (
     <div
       className="min-h-screen p-8 pb-20 sm:p-20 font-sans grid place-items-center"

--- a/src/app/(protected)/not-found.tsx
+++ b/src/app/(protected)/not-found.tsx
@@ -1,13 +1,13 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
-export default function ApplicationsNotFound() {
+export default function ProtectedNotFound() {
   return (
     <div className="min-h-screen p-8 pb-20 sm:p-20 font-sans grid place-items-center">
       <div className="max-w-xl w-full text-center space-y-4">
         <h1 className="text-2xl sm:text-3xl font-semibold">Not found</h1>
         <p className="text-muted-foreground">
-          We couldn&apos;t find the application you&apos;re looking for.
+          We couldn&apos;t find the page you&apos;re looking for.
         </p>
         <div className="flex items-center justify-center gap-3 pt-2">
           <Button asChild>

--- a/src/components/tables/MatchingLendersTable.tsx
+++ b/src/components/tables/MatchingLendersTable.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import React from "react";
+import Link from "next/link";
 import type { ColumnDef } from "@tanstack/react-table";
 import { DataTable } from "@/components/tables/data-table";
 import type { MatchingLenderRow } from "@/types/applications";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 
 const columns: ColumnDef<MatchingLenderRow, unknown>[] = [
   { 
@@ -132,6 +134,17 @@ const columns: ColumnDef<MatchingLenderRow, unknown>[] = [
         {row.original.notes || "-"}
       </div>
     ),
+  },
+  {
+    id: "action",
+    cell: ({ row }) => {
+      const id = row.original.id;
+      return (
+        <Button asChild size="sm">
+          <Link href={`/lenders/${id}`}>View</Link>
+        </Button>
+      );
+    },
   },
 ];
 

--- a/src/lib/fetchLender.ts
+++ b/src/lib/fetchLender.ts
@@ -1,0 +1,57 @@
+import type { MatchingLenderApi } from "../types/api";
+
+type FetchOptions = {
+  timeoutMs?: number;
+};
+
+/**
+ * Factory that returns a function to fetch a single lender record by id.
+ * Handles env validation, timeout, 404 -> null, and safe JSON parsing.
+ */
+export function createLenderFetcher(options: FetchOptions = {}) {
+  const { timeoutMs = 15000 } = options;
+
+  return async function fetchLender(
+    id: string | number
+  ): Promise<MatchingLenderApi | null> {
+    const API_URL = process.env.API_URL;
+    if (!API_URL) {
+      throw new Error("API_URL environment variable is not set");
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const url = `${API_URL}/lenders/${id}`;
+      const res = await fetch(url, {
+        headers: { "x-fillout-secret": process.env.X_FILLOUT_SECRET || "" },
+        cache: "no-store",
+        signal: controller.signal,
+      });
+
+      if (res.status === 404) return null;
+      if (!res.ok) return null;
+
+      try {
+        const raw = await res.json();
+        return (
+          (Array.isArray(raw) ? (raw as MatchingLenderApi[])[0] : (raw as MatchingLenderApi)) ??
+          null
+        );
+      } catch {
+        return null;
+      }
+    } catch (err: unknown) {
+      if ((err as Error)?.name === "AbortError") {
+        throw new Error("Request timed out while fetching lender");
+      }
+      throw new Error((err as Error)?.message || "Unexpected fetch error");
+    } finally {
+      clearTimeout(timeout);
+    }
+  };
+}
+
+// Default instance for convenience
+export const fetchLender = createLenderFetcher();

--- a/src/lib/transformers/matchingLenders.ts
+++ b/src/lib/transformers/matchingLenders.ts
@@ -39,12 +39,18 @@ function formatNumber(value: number | string | null | undefined): string {
 /**
  * Parses a comma-separated string into an array
  */
-function parseCommaSeparated(value: string | null | undefined): string[] {
+function parseCommaSeparated(
+  value: string | string[] | null | undefined
+): string[] {
   if (!value) return [];
-  return value
-    .split(",")
-    .map((item) => item.trim())
-    .filter(Boolean);
+  if (Array.isArray(value)) return value;
+  if (typeof value === "string") {
+    return value
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+  return [];
 }
 
 /**
@@ -56,7 +62,7 @@ function createLoanRangeDisplay(
 ): string {
   const minFormatted = formatCurrency(loanMin);
   const maxFormatted = formatCurrency(loanMax);
-  
+
   if (minFormatted && maxFormatted) {
     return `${minFormatted} - ${maxFormatted}`;
   } else if (minFormatted) {
@@ -84,14 +90,14 @@ export function transformMatchingLenders(
       contactName: r.contact_name ?? "",
       contactPhone: r.contact_phone ?? "",
       contactEmail: r.contact_email ?? "",
-      
+
       loanRangeDisplay: createLoanRangeDisplay(r.loan_min, r.loan_max),
       maxLtvDisplay: formatPercent(r.max_ltv),
       ficoMinDisplay: formatNumber(r.fico_min),
-      
+
       lendingStates: parseCommaSeparated(r.lending_states),
       propertyTypes: parseCommaSeparated(r.property_types),
-      
+
       notes: r.notes ?? "",
     };
   });


### PR DESCRIPTION
## Summary
- Implemented lender details page UI
- Implemented service that fetches singular lender record by ID
- Extracted re-usable layouts e.g `error.tsx`, `loading.tsx` and `not-found.tsx` so it can be re-used by different route segments under the `(protected)` segment

## Screenshots
<img width="1916" height="933" alt="Screenshot 2025-09-06 at 2 13 11 AM" src="https://github.com/user-attachments/assets/e20ebec5-43dd-4560-89f2-45a2b4fd6cbb" />
